### PR TITLE
reduce size of snippet

### DIFF
--- a/Colored Sidebar Items.css
+++ b/Colored Sidebar Items.css
@@ -94,558 +94,105 @@ between the prefix groups are the color variables. Change or expand on any of
 these to suit your own folder structure and vault theme!
 */
 
-/* ------------------------------- 00 Prefix -------------------------------- */
-.nav-folder-title[data-path^="00"] {
-  color: var(--mint);
+/* ------------------------------- Base -------------------------------- */
+.nav-folder-title {
+  color: var(--color);
   --nav-item-color-hover: color-mix(
     in srgb,
-    var(--mint) var(--fg-contrast-amount),
+    var(--color) var(--fg-contrast-amount),
     var(--contrast-color)
   );
   --nav-item-background-hover: color-mix(
     in srgb,
-    var(--mint) var(--bg-contrast-amount),
+    var(--color) var(--bg-contrast-amount),
     transparent
   );
   --background-modifier-border-focus: color-mix(
     in srgb,
-    var(--mint) 40%,
+    var(--color) 40%,
     transparent
   );
-  --nav-collapse-icon-color: color-mix(in srgb, var(--mint) 60%, transparent);
+  --nav-collapse-icon-color: color-mix(in srgb, var(--color) 60%, transparent);
 }
-.nav-folder-title[data-path^="00"]:hover {
+.nav-folder-title:hover {
   --nav-collapse-icon-color: color-mix(
     in srgb,
-    var(--mint) 60%,
+    var(--color) 60%,
     var(--contrast-color)
   );
 }
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="00"]) {
+.tree-item-children .nav-folder:has(.nav-folder-title) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
-    var(--mint) var(--medium-contrast-amount),
+    var(--color) var(--medium-contrast-amount),
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="00"])
-  .nav-file-title {
+.tree-item-children .nav-folder:has(.nav-folder-title) .nav-file-title {
   color: color-mix(
     in srgb,
-    var(--mint) var(--medium-contrast-amount),
+    var(--color) var(--medium-contrast-amount),
     var(--default-text-color)
   );
   --nav-item-background-hover: color-mix(
     in srgb,
-    color-mix(in srgb, var(--mint) 50%, var(--highlight))
+    color-mix(in srgb, var(--color) 50%, var(--highlight))
       var(--bg-contrast-amount),
     transparent
   );
   --background-modifier-border-focus: color-mix(
     in srgb,
-    var(--mint) 40%,
+    var(--color) 40%,
     transparent
   );
   --nav-item-background-active: color-mix(
     in srgb,
-    var(--mint) var(--active-contrast-amount),
+    var(--color) var(--active-contrast-amount),
     transparent
   );
+}
+
+/* ------------------------------- 00 Prefix -------------------------------- */
+.nav-folder-title[data-path^="00"] {
+  --color: var(--mint);
 }
 
 /* ------------------------------- 01 Prefix -------------------------------- */
 .nav-folder-title[data-path^="01"] {
-  color: var(--cyan);
-  --nav-item-color-hover: color-mix(
-    in srgb,
-    var(--cyan) var(--fg-contrast-amount),
-    var(--contrast-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    var(--cyan) var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--cyan) 40%,
-    transparent
-  );
-  --nav-collapse-icon-color: color-mix(in srgb, var(--cyan) 60%, transparent);
-}
-.nav-folder-title[data-path^="01"]:hover {
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--cyan) 60%,
-    var(--contrast-color)
-  );
-}
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="01"]) {
-  --nav-indentation-guide-color: color-mix(
-    in srgb,
-    var(--cyan) var(--medium-contrast-amount),
-    transparent
-  );
-}
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="01"])
-  .nav-file-title {
-  color: color-mix(
-    in srgb,
-    var(--cyan) var(--medium-contrast-amount),
-    var(--default-text-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    color-mix(in srgb, var(--cyan) 50%, var(--highlight))
-      var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--cyan) 40%,
-    transparent
-  );
-  --nav-item-background-active: color-mix(
-    in srgb,
-    var(--cyan) var(--active-contrast-amount),
-    transparent
-  );
+  --color: var(--cyan);
 }
 
 /* ------------------------------- 02 Prefix -------------------------------- */
 .nav-folder-title[data-path^="02"] {
-  color: var(--light-blue);
-  --nav-item-color-hover: color-mix(
-    in srgb,
-    var(--light-blue) var(--fg-contrast-amount),
-    var(--contrast-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    var(--light-blue) var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--light-blue) 40%,
-    transparent
-  );
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--light-blue) 60%,
-    transparent
-  );
-}
-.nav-folder-title[data-path^="02"]:hover {
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--light-blue) 60%,
-    var(--contrast-color)
-  );
-}
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="02"]) {
-  --nav-indentation-guide-color: color-mix(
-    in srgb,
-    var(--light-blue) var(--medium-contrast-amount),
-    transparent
-  );
-}
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="02"])
-  .nav-file-title {
-  color: color-mix(
-    in srgb,
-    var(--light-blue) var(--medium-contrast-amount),
-    var(--default-text-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    color-mix(in srgb, var(--light-blue) 50%, var(--highlight))
-      var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--light-blue) 40%,
-    transparent
-  );
-  --nav-item-background-active: color-mix(
-    in srgb,
-    var(--light-blue) var(--active-contrast-amount),
-    transparent
-  );
+  --color: var(--light-blue);
 }
 
 /* ------------------------------- 03 Prefix -------------------------------- */
 .nav-folder-title[data-path^="03"] {
-  color: var(--blue);
-  --nav-item-color-hover: color-mix(
-    in srgb,
-    var(--blue) var(--fg-contrast-amount),
-    var(--contrast-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    var(--blue) var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--blue) 40%,
-    transparent
-  );
-  --nav-collapse-icon-color: color-mix(in srgb, var(--blue) 60%, transparent);
-}
-.nav-folder-title[data-path^="03"]:hover {
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--blue) 60%,
-    var(--contrast-color)
-  );
-}
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="03"]) {
-  --nav-indentation-guide-color: color-mix(
-    in srgb,
-    var(--blue) var(--medium-contrast-amount),
-    transparent
-  );
-}
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="03"])
-  .nav-file-title {
-  color: color-mix(
-    in srgb,
-    var(--blue) var(--medium-contrast-amount),
-    var(--default-text-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    color-mix(in srgb, var(--blue) 50%, var(--highlight))
-      var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--blue) 40%,
-    transparent
-  );
-  --nav-item-background-active: color-mix(
-    in srgb,
-    var(--blue) var(--active-contrast-amount),
-    transparent
-  );
+  --color: var(--blue);
 }
 
 /* ------------------------------- 04 Prefix -------------------------------- */
 .nav-folder-title[data-path^="04"] {
-  color: var(--violet);
-  --nav-item-color-hover: color-mix(
-    in srgb,
-    var(--violet) var(--fg-contrast-amount),
-    var(--contrast-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    var(--violet) var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--violet) 40%,
-    transparent
-  );
-  --nav-collapse-icon-color: color-mix(in srgb, var(--violet) 60%, transparent);
-}
-.nav-folder-title[data-path^="04"]:hover {
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--violet) 60%,
-    var(--contrast-color)
-  );
-}
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="04"]) {
-  --nav-indentation-guide-color: color-mix(
-    in srgb,
-    var(--violet) var(--medium-contrast-amount),
-    transparent
-  );
-}
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="04"])
-  .nav-file-title {
-  color: color-mix(
-    in srgb,
-    var(--violet) var(--medium-contrast-amount),
-    var(--default-text-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    color-mix(in srgb, var(--violet) 50%, var(--highlight))
-      var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--violet) 40%,
-    transparent
-  );
-  --nav-item-background-active: color-mix(
-    in srgb,
-    var(--violet) var(--active-contrast-amount),
-    transparent
-  );
+  --color: var(--violet);
 }
 
 /* ------------------------------- 05 Prefix -------------------------------- */
 .nav-folder-title[data-path^="05"] {
-  color: var(--purple);
-  --nav-item-color-hover: color-mix(
-    in srgb,
-    var(--purple) var(--fg-contrast-amount),
-    var(--contrast-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    var(--purple) var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--purple) 40%,
-    transparent
-  );
-  --nav-collapse-icon-color: color-mix(in srgb, var(--purple) 60%, transparent);
-}
-.nav-folder-title[data-path^="05"]:hover {
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--purple) 60%,
-    var(--contrast-color)
-  );
-}
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="05"]) {
-  --nav-indentation-guide-color: color-mix(
-    in srgb,
-    var(--purple) var(--medium-contrast-amount),
-    transparent
-  );
-}
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="05"])
-  .nav-file-title {
-  color: color-mix(
-    in srgb,
-    var(--purple) var(--medium-contrast-amount),
-    var(--default-text-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    color-mix(in srgb, var(--purple) 50%, var(--highlight))
-      var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--purple) 40%,
-    transparent
-  );
-  --nav-item-background-active: color-mix(
-    in srgb,
-    var(--purple) var(--active-contrast-amount),
-    transparent
-  );
+  --color: var(--purple);
 }
 
 /* ------------------------------- 06 Prefix -------------------------------- */
 .nav-folder-title[data-path^="06"] {
-  color: var(--magenta);
-  --nav-item-color-hover: color-mix(
-    in srgb,
-    var(--magenta) var(--fg-contrast-amount),
-    var(--contrast-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    var(--magenta) var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--magenta) 40%,
-    transparent
-  );
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--magenta) 60%,
-    transparent
-  );
-}
-.nav-folder-title[data-path^="06"]:hover {
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--magenta) 60%,
-    var(--contrast-color)
-  );
-}
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="06"]) {
-  --nav-indentation-guide-color: color-mix(
-    in srgb,
-    var(--magenta) var(--medium-contrast-amount),
-    transparent
-  );
-}
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="06"])
-  .nav-file-title {
-  color: color-mix(
-    in srgb,
-    var(--magenta) var(--medium-contrast-amount),
-    var(--default-text-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    color-mix(in srgb, var(--magenta) 50%, var(--highlight))
-      var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--magenta) 40%,
-    transparent
-  );
-  --nav-item-background-active: color-mix(
-    in srgb,
-    var(--magenta) var(--active-contrast-amount),
-    transparent
-  );
+  --color: var(--magenta);
 }
 
 /* ------------------------------- 07 Prefix -------------------------------- */
 .nav-folder-title[data-path^="07"] {
-  color: var(--hot-red);
-  --nav-item-color-hover: color-mix(
-    in srgb,
-    var(--hot-red) var(--fg-contrast-amount),
-    var(--contrast-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    var(--hot-red) var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--hot-red) 40%,
-    transparent
-  );
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--hot-red) 60%,
-    transparent
-  );
-}
-.nav-folder-title[data-path^="07"]:hover {
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--hot-red) 60%,
-    var(--contrast-color)
-  );
-}
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="07"]) {
-  --nav-indentation-guide-color: color-mix(
-    in srgb,
-    var(--hot-red) var(--medium-contrast-amount),
-    transparent
-  );
-}
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="07"])
-  .nav-file-title {
-  color: color-mix(
-    in srgb,
-    var(--hot-red) var(--medium-contrast-amount),
-    var(--default-text-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    color-mix(in srgb, var(--hot-red) 50%, var(--highlight))
-      var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--hot-red) 40%,
-    transparent
-  );
-  --nav-item-background-active: color-mix(
-    in srgb,
-    var(--hot-red) var(--active-contrast-amount),
-    transparent
-  );
+  --color: var(--hot-red);
 }
 
 /* ------------------------------- 99 Prefix -------------------------------- */
 .nav-folder-title[data-path^="99"] {
-  color: var(--cool-gray);
-  --nav-item-color-hover: color-mix(
-    in srgb,
-    var(--cool-gray) var(--fg-contrast-amount),
-    var(--contrast-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    var(--cool-gray) var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--cool-gray) 40%,
-    transparent
-  );
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--cool-gray) 60%,
-    transparent
-  );
-}
-.nav-folder-title[data-path^="99"]:hover {
-  --nav-collapse-icon-color: color-mix(
-    in srgb,
-    var(--cool-gray) 60%,
-    var(--contrast-color)
-  );
-}
-.tree-item-children .nav-folder:has(.nav-folder-title[data-path^="99"]) {
-  --nav-indentation-guide-color: color-mix(
-    in srgb,
-    var(--cool-gray) var(--medium-contrast-amount),
-    transparent
-  );
-}
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="99"])
-  .nav-file-title {
-  color: color-mix(
-    in srgb,
-    var(--cool-gray) var(--medium-contrast-amount),
-    var(--default-text-color)
-  );
-  --nav-item-background-hover: color-mix(
-    in srgb,
-    color-mix(in srgb, var(--cool-gray) 50%, var(--highlight))
-      var(--bg-contrast-amount),
-    transparent
-  );
-  --background-modifier-border-focus: color-mix(
-    in srgb,
-    var(--cool-gray) 40%,
-    transparent
-  );
-  --nav-item-background-active: color-mix(
-    in srgb,
-    var(--cool-gray) var(--active-contrast-amount),
-    transparent
-  );
+  --color: var(--cool-gray);
 }


### PR DESCRIPTION
no worries if explicit is better than clever, but just saw an opportunity to potentially make this:

- easier to maintain
- easier for the layperson to update. 

tested and works on my computer at the least:

<img width="357" alt="Screenshot 2024-08-28 at 18 12 47" src="https://github.com/user-attachments/assets/5d1e0a3e-1cee-4b77-b5de-1608062d5d6c">
