### PR TITLE
Update Colored Sidebar Items.css

### DIFF
--- a/Colored Sidebar Items.css
+++ b/Colored Sidebar Items.css
@@ -121,6 +121,8 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+/* changes to the indentation guide's color apply under the main folder as well, and not just under children folders (done for all prefixes) */
+.nav-folder:has(.nav-folder-title[data-path^="00"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="00"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -128,9 +130,10 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="00"])
-  .nav-file-title {
+/* Target files directly within the first folder with "00" prefix */
+/* now will also target files in main folder with "00" prefix, and not just the ones within children folders (done for all prefixes) */
+.nav-folder-title[data-path^="00"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="00"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--mint) var(--medium-contrast-amount),
@@ -153,7 +156,6 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-
 /* ------------------------------- 01 Prefix -------------------------------- */
 .nav-folder-title[data-path^="01"] {
   color: var(--cyan);
@@ -181,6 +183,7 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+.nav-folder:has(.nav-folder-title[data-path^="01"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="01"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -188,9 +191,8 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="01"])
-  .nav-file-title {
+.nav-folder-title[data-path^="01"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="01"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--cyan) var(--medium-contrast-amount),
@@ -245,6 +247,7 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+.nav-folder:has(.nav-folder-title[data-path^="02"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="02"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -252,9 +255,8 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="02"])
-  .nav-file-title {
+.nav-folder-title[data-path^="02"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="02"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--light-blue) var(--medium-contrast-amount),
@@ -305,6 +307,7 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+.nav-folder:has(.nav-folder-title[data-path^="03"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="03"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -312,9 +315,8 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="03"])
-  .nav-file-title {
+.nav-folder-title[data-path^="03"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="03"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--blue) var(--medium-contrast-amount),
@@ -365,6 +367,7 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+.nav-folder:has(.nav-folder-title[data-path^="04"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="04"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -372,9 +375,8 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="04"])
-  .nav-file-title {
+.nav-folder-title[data-path^="04"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="04"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--violet) var(--medium-contrast-amount),
@@ -425,6 +427,7 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+.nav-folder:has(.nav-folder-title[data-path^="05"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="05"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -432,9 +435,8 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="05"])
-  .nav-file-title {
+.nav-folder-title[data-path^="05"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="05"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--purple) var(--medium-contrast-amount),
@@ -489,6 +491,7 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+.nav-folder:has(.nav-folder-title[data-path^="06"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="06"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -496,9 +499,8 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="06"])
-  .nav-file-title {
+.nav-folder-title[data-path^="06"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="06"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--magenta) var(--medium-contrast-amount),
@@ -553,6 +555,7 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+.nav-folder:has(.nav-folder-title[data-path^="07"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="07"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -560,9 +563,8 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="07"])
-  .nav-file-title {
+.nav-folder-title[data-path^="07"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="07"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--hot-red) var(--medium-contrast-amount),
@@ -617,6 +619,7 @@ these to suit your own folder structure and vault theme!
     var(--contrast-color)
   );
 }
+.nav-folder:has(.nav-folder-title[data-path^="99"]),
 .tree-item-children .nav-folder:has(.nav-folder-title[data-path^="99"]) {
   --nav-indentation-guide-color: color-mix(
     in srgb,
@@ -624,9 +627,8 @@ these to suit your own folder structure and vault theme!
     transparent
   );
 }
-.tree-item-children
-  .nav-folder:has(.nav-folder-title[data-path^="99"])
-  .nav-file-title {
+.nav-folder-title[data-path^="99"] ~ .tree-item-children .nav-file-title,
+.nav-folder-title[data-path^="99"] ~ .tree-item-children .nav-folder .nav-file-title {
   color: color-mix(
     in srgb,
     var(--cool-gray) var(--medium-contrast-amount),


### PR DESCRIPTION
Color changes under "prefix folders" will also apply to files within the first folders, and to the indentation guide of the first folder.

Original:
![image](https://github.com/user-attachments/assets/db51d598-6151-4991-9849-00f2c0520b47)

Updated:
![image](https://github.com/user-attachments/assets/e2b4f73c-f96e-4d32-b23e-52c4d5300fbc)

It is nothing of really impactful, but its absence struck my eyes as soon as I tried the snippet out. Even tho its use really depends on personal preferences, I still tried to fix the issue.